### PR TITLE
Removing the master/slave language

### DIFF
--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -220,12 +220,12 @@ func (db *sqlite3) IndexOnTable() bool {
 
 func (db *sqlite3) IndexCheckSql(tableName, idxName string) (string, []interface{}) {
 	args := []interface{}{idxName}
-	return "SELECT name FROM sqlite_master WHERE type='index' and name = ?", args
+	return "SELECT name FROM sqlite_main WHERE type='index' and name = ?", args
 }
 
 func (db *sqlite3) TableCheckSql(tableName string) (string, []interface{}) {
 	args := []interface{}{tableName}
-	return "SELECT name FROM sqlite_master WHERE type='table' and name = ?", args
+	return "SELECT name FROM sqlite_main WHERE type='table' and name = ?", args
 }
 
 func (db *sqlite3) CreateIndexSql(tableName string, index *core.Index) string {
@@ -263,13 +263,13 @@ func (db *sqlite3) ForUpdateSql(query string) string {
 
 /*func (db *sqlite3) ColumnCheckSql(tableName, colName string) (string, []interface{}) {
 	args := []interface{}{tableName}
-	sql := "SELECT name FROM sqlite_master WHERE type='table' and name = ? and ((sql like '%`" + colName + "`%') or (sql like '%[" + colName + "]%'))"
+	sql := "SELECT name FROM sqlite_main WHERE type='table' and name = ? and ((sql like '%`" + colName + "`%') or (sql like '%[" + colName + "]%'))"
 	return sql, args
 }*/
 
 func (db *sqlite3) IsColumnExist(tableName, colName string) (bool, error) {
 	args := []interface{}{tableName}
-	query := "SELECT name FROM sqlite_master WHERE type='table' and name = ? and ((sql like '%`" + colName + "`%') or (sql like '%[" + colName + "]%'))"
+	query := "SELECT name FROM sqlite_main WHERE type='table' and name = ? and ((sql like '%`" + colName + "`%') or (sql like '%[" + colName + "]%'))"
 	db.LogSQL(query, args)
 	rows, err := db.DB().Query(query, args...)
 	if err != nil {
@@ -285,7 +285,7 @@ func (db *sqlite3) IsColumnExist(tableName, colName string) (bool, error) {
 
 func (db *sqlite3) GetColumns(tableName string) ([]string, map[string]*core.Column, error) {
 	args := []interface{}{tableName}
-	s := "SELECT sql FROM sqlite_master WHERE type='table' and name = ?"
+	s := "SELECT sql FROM sqlite_main WHERE type='table' and name = ?"
 	db.LogSQL(s, args)
 	rows, err := db.DB().Query(s, args...)
 	if err != nil {
@@ -368,7 +368,7 @@ func (db *sqlite3) GetColumns(tableName string) ([]string, map[string]*core.Colu
 
 func (db *sqlite3) GetTables() ([]*core.Table, error) {
 	args := []interface{}{}
-	s := "SELECT name FROM sqlite_master WHERE type='table'"
+	s := "SELECT name FROM sqlite_main WHERE type='table'"
 	db.LogSQL(s, args)
 
 	rows, err := db.DB().Query(s, args...)
@@ -394,7 +394,7 @@ func (db *sqlite3) GetTables() ([]*core.Table, error) {
 
 func (db *sqlite3) GetIndexes(tableName string) (map[string]*core.Index, error) {
 	args := []interface{}{tableName}
-	s := "SELECT sql FROM sqlite_master WHERE type='index' and tbl_name = ?"
+	s := "SELECT sql FROM sqlite_main WHERE type='index' and tbl_name = ?"
 	db.LogSQL(s, args)
 
 	rows, err := db.DB().Query(s, args...)

--- a/engine_group.go
+++ b/engine_group.go
@@ -14,7 +14,7 @@ import (
 // EngineGroup defines an engine group
 type EngineGroup struct {
 	*Engine
-	slaves []*Engine
+	subordinates []*Engine
 	policy GroupPolicy
 }
 
@@ -41,19 +41,19 @@ func NewEngineGroup(args1 interface{}, args2 interface{}, policies ...GroupPolic
 		}
 
 		eg.Engine = engines[0]
-		eg.slaves = engines[1:]
+		eg.subordinates = engines[1:]
 		return &eg, nil
 	}
 
-	master, ok3 := args1.(*Engine)
-	slaves, ok4 := args2.([]*Engine)
+	main, ok3 := args1.(*Engine)
+	subordinates, ok4 := args2.([]*Engine)
 	if ok3 && ok4 {
-		master.engineGroup = &eg
-		for i := 0; i < len(slaves); i++ {
-			slaves[i].engineGroup = &eg
+		main.engineGroup = &eg
+		for i := 0; i < len(subordinates); i++ {
+			subordinates[i].engineGroup = &eg
 		}
-		eg.Engine = master
-		eg.slaves = slaves
+		eg.Engine = main
+		eg.subordinates = subordinates
 		return &eg, nil
 	}
 	return nil, ErrParamsType
@@ -66,8 +66,8 @@ func (eg *EngineGroup) Close() error {
 		return err
 	}
 
-	for i := 0; i < len(eg.slaves); i++ {
-		err := eg.slaves[i].Close()
+	for i := 0; i < len(eg.subordinates); i++ {
+		err := eg.subordinates[i].Close()
 		if err != nil {
 			return err
 		}
@@ -89,8 +89,8 @@ func (eg *EngineGroup) NewSession() *Session {
 	return sess
 }
 
-// Master returns the master engine
-func (eg *EngineGroup) Master() *Engine {
+// Main returns the main engine
+func (eg *EngineGroup) Main() *Engine {
 	return eg.Engine
 }
 
@@ -100,8 +100,8 @@ func (eg *EngineGroup) Ping() error {
 		return err
 	}
 
-	for _, slave := range eg.slaves {
-		if err := slave.Ping(); err != nil {
+	for _, subordinate := range eg.subordinates {
+		if err := subordinate.Ping(); err != nil {
 			return err
 		}
 	}
@@ -111,64 +111,64 @@ func (eg *EngineGroup) Ping() error {
 // SetColumnMapper set the column name mapping rule
 func (eg *EngineGroup) SetColumnMapper(mapper core.IMapper) {
 	eg.Engine.ColumnMapper = mapper
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].ColumnMapper = mapper
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].ColumnMapper = mapper
 	}
 }
 
 // SetConnMaxLifetime sets the maximum amount of time a connection may be reused.
 func (eg *EngineGroup) SetConnMaxLifetime(d time.Duration) {
 	eg.Engine.SetConnMaxLifetime(d)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].SetConnMaxLifetime(d)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].SetConnMaxLifetime(d)
 	}
 }
 
 // SetDefaultCacher set the default cacher
 func (eg *EngineGroup) SetDefaultCacher(cacher core.Cacher) {
 	eg.Engine.SetDefaultCacher(cacher)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].SetDefaultCacher(cacher)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].SetDefaultCacher(cacher)
 	}
 }
 
 // SetLogger set the new logger
 func (eg *EngineGroup) SetLogger(logger core.ILogger) {
 	eg.Engine.SetLogger(logger)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].SetLogger(logger)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].SetLogger(logger)
 	}
 }
 
 // SetLogLevel sets the logger level
 func (eg *EngineGroup) SetLogLevel(level core.LogLevel) {
 	eg.Engine.SetLogLevel(level)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].SetLogLevel(level)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].SetLogLevel(level)
 	}
 }
 
 // SetMapper set the name mapping rules
 func (eg *EngineGroup) SetMapper(mapper core.IMapper) {
 	eg.Engine.SetMapper(mapper)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].SetMapper(mapper)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].SetMapper(mapper)
 	}
 }
 
 // SetMaxIdleConns set the max idle connections on pool, default is 2
 func (eg *EngineGroup) SetMaxIdleConns(conns int) {
 	eg.Engine.db.SetMaxIdleConns(conns)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].db.SetMaxIdleConns(conns)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].db.SetMaxIdleConns(conns)
 	}
 }
 
 // SetMaxOpenConns is only available for go 1.2+
 func (eg *EngineGroup) SetMaxOpenConns(conns int) {
 	eg.Engine.db.SetMaxOpenConns(conns)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].db.SetMaxOpenConns(conns)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].db.SetMaxOpenConns(conns)
 	}
 }
 
@@ -181,41 +181,41 @@ func (eg *EngineGroup) SetPolicy(policy GroupPolicy) *EngineGroup {
 // SetTableMapper set the table name mapping rule
 func (eg *EngineGroup) SetTableMapper(mapper core.IMapper) {
 	eg.Engine.TableMapper = mapper
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].TableMapper = mapper
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].TableMapper = mapper
 	}
 }
 
 // ShowExecTime show SQL statement and execute time or not on logger if log level is great than INFO
 func (eg *EngineGroup) ShowExecTime(show ...bool) {
 	eg.Engine.ShowExecTime(show...)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].ShowExecTime(show...)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].ShowExecTime(show...)
 	}
 }
 
 // ShowSQL show SQL statement or not on logger if log level is great than INFO
 func (eg *EngineGroup) ShowSQL(show ...bool) {
 	eg.Engine.ShowSQL(show...)
-	for i := 0; i < len(eg.slaves); i++ {
-		eg.slaves[i].ShowSQL(show...)
+	for i := 0; i < len(eg.subordinates); i++ {
+		eg.subordinates[i].ShowSQL(show...)
 	}
 }
 
-// Slave returns one of the physical databases which is a slave according the policy
-func (eg *EngineGroup) Slave() *Engine {
-	switch len(eg.slaves) {
+// Subordinate returns one of the physical databases which is a subordinate according the policy
+func (eg *EngineGroup) Subordinate() *Engine {
+	switch len(eg.subordinates) {
 	case 0:
 		return eg.Engine
 	case 1:
-		return eg.slaves[0]
+		return eg.subordinates[0]
 	}
-	return eg.policy.Slave(eg)
+	return eg.policy.Subordinate(eg)
 }
 
-// Slaves returns all the slaves
-func (eg *EngineGroup) Slaves() []*Engine {
-	return eg.slaves
+// Subordinates returns all the subordinates
+func (eg *EngineGroup) Subordinates() []*Engine {
+	return eg.subordinates
 }
 
 func (eg *EngineGroup) RegisterSqlTemplate(sqlt SqlTemplate, Cipher ...Cipher) error {
@@ -223,8 +223,8 @@ func (eg *EngineGroup) RegisterSqlTemplate(sqlt SqlTemplate, Cipher ...Cipher) e
 	if err != nil {
 		return err
 	}
-	for i := 0; i < len(eg.slaves); i++ {
-		err = eg.slaves[i].RegisterSqlTemplate(sqlt, Cipher...)
+	for i := 0; i < len(eg.subordinates); i++ {
+		err = eg.subordinates[i].RegisterSqlTemplate(sqlt, Cipher...)
 		if err != nil {
 			return err
 		}
@@ -237,8 +237,8 @@ func (eg *EngineGroup) RegisterSqlMap(sqlm SqlM, Cipher ...Cipher) error {
 	if err != nil {
 		return err
 	}
-	for i := 0; i < len(eg.slaves); i++ {
-		err = eg.slaves[i].RegisterSqlMap(sqlm, Cipher...)
+	for i := 0; i < len(eg.subordinates); i++ {
+		err = eg.subordinates[i].RegisterSqlMap(sqlm, Cipher...)
 		if err != nil {
 			return err
 		}

--- a/engine_group_policy.go
+++ b/engine_group_policy.go
@@ -10,28 +10,28 @@ import (
 	"time"
 )
 
-// GroupPolicy is be used by chosing the current slave from slaves
+// GroupPolicy is be used by chosing the current subordinate from subordinates
 type GroupPolicy interface {
-	Slave(*EngineGroup) *Engine
+	Subordinate(*EngineGroup) *Engine
 }
 
 // GroupPolicyHandler should be used when a function is a GroupPolicy
 type GroupPolicyHandler func(*EngineGroup) *Engine
 
-// Slave implements the chosen of slaves
-func (h GroupPolicyHandler) Slave(eg *EngineGroup) *Engine {
+// Subordinate implements the chosen of subordinates
+func (h GroupPolicyHandler) Subordinate(eg *EngineGroup) *Engine {
 	return h(eg)
 }
 
-// RandomPolicy implmentes randomly chose the slave of slaves
+// RandomPolicy implmentes randomly chose the subordinate of subordinates
 func RandomPolicy() GroupPolicyHandler {
 	var r = rand.New(rand.NewSource(time.Now().UnixNano()))
 	return func(g *EngineGroup) *Engine {
-		return g.Slaves()[r.Intn(len(g.Slaves()))]
+		return g.Subordinates()[r.Intn(len(g.Subordinates()))]
 	}
 }
 
-// WeightRandomPolicy implmentes randomly chose the slave of slaves
+// WeightRandomPolicy implmentes randomly chose the subordinate of subordinates
 func WeightRandomPolicy(weights []int) GroupPolicyHandler {
 	var rands = make([]int, 0, len(weights))
 	for i := 0; i < len(weights); i++ {
@@ -42,12 +42,12 @@ func WeightRandomPolicy(weights []int) GroupPolicyHandler {
 	var r = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	return func(g *EngineGroup) *Engine {
-		var slaves = g.Slaves()
+		var subordinates = g.Subordinates()
 		idx := rands[r.Intn(len(rands))]
-		if idx >= len(slaves) {
-			idx = len(slaves) - 1
+		if idx >= len(subordinates) {
+			idx = len(subordinates) - 1
 		}
-		return slaves[idx]
+		return subordinates[idx]
 	}
 }
 
@@ -55,16 +55,16 @@ func RoundRobinPolicy() GroupPolicyHandler {
 	var pos = -1
 	var lock sync.Mutex
 	return func(g *EngineGroup) *Engine {
-		var slaves = g.Slaves()
+		var subordinates = g.Subordinates()
 
 		lock.Lock()
 		defer lock.Unlock()
 		pos++
-		if pos >= len(slaves) {
+		if pos >= len(subordinates) {
 			pos = 0
 		}
 
-		return slaves[pos]
+		return subordinates[pos]
 	}
 }
 
@@ -79,7 +79,7 @@ func WeightRoundRobinPolicy(weights []int) GroupPolicyHandler {
 	var lock sync.Mutex
 
 	return func(g *EngineGroup) *Engine {
-		var slaves = g.Slaves()
+		var subordinates = g.Subordinates()
 		lock.Lock()
 		defer lock.Unlock()
 		pos++
@@ -88,21 +88,21 @@ func WeightRoundRobinPolicy(weights []int) GroupPolicyHandler {
 		}
 
 		idx := rands[pos]
-		if idx >= len(slaves) {
-			idx = len(slaves) - 1
+		if idx >= len(subordinates) {
+			idx = len(subordinates) - 1
 		}
-		return slaves[idx]
+		return subordinates[idx]
 	}
 }
 
-// LeastConnPolicy implements GroupPolicy, every time will get the least connections slave
+// LeastConnPolicy implements GroupPolicy, every time will get the least connections subordinate
 func LeastConnPolicy() GroupPolicyHandler {
 	return func(g *EngineGroup) *Engine {
-		var slaves = g.Slaves()
+		var subordinates = g.Subordinates()
 		connections := 0
 		idx := 0
-		for i := 0; i < len(slaves); i++ {
-			openConnections := slaves[i].DB().Stats().OpenConnections
+		for i := 0; i < len(subordinates); i++ {
+			openConnections := subordinates[i].DB().Stats().OpenConnections
 			if i == 0 {
 				connections = openConnections
 				idx = i
@@ -111,6 +111,6 @@ func LeastConnPolicy() GroupPolicyHandler {
 				idx = i
 			}
 		}
-		return slaves[idx]
+		return subordinates[idx]
 	}
 }

--- a/xorm_test.go
+++ b/xorm_test.go
@@ -47,7 +47,7 @@ func createEngine(dbType, connStr string) error {
 			if strings.ToLower(dbType) != core.MSSQL {
 				db, err = sql.Open(dbType, connStr)
 			} else {
-				db, err = sql.Open(dbType, strings.Replace(connStr, "xorm_test", "master", -1))
+				db, err = sql.Open(dbType, strings.Replace(connStr, "xorm_test", "main", -1))
 			}
 
 			if err != nil {


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.